### PR TITLE
Add visdat location to Remotes field

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -35,6 +35,8 @@ Imports:
     magrittr,
     stats,
     visdat
+Remotes:
+    njtierney/visdat
 RoxygenNote: 5.0.1
 Collate:
     'add_cols.R'


### PR DESCRIPTION
Oops, I forgot to add `njtierney/visdat` to the Remotes field in the DESCRIPTION file.

`devtools` needs to know the GitHub location for all non-CRAN packages. I suppose it built for myself since I already had the `visdat` package installed. You can see [this `devtools` vignette](https://cran.r-project.org/web/packages/devtools/vignettes/dependencies.html) for more info.