### PR TITLE
Use rowSums / rowMeans to compute row-wise summaries

### DIFF
--- a/R/add-n-prop-miss.R
+++ b/R/add-n-prop-miss.R
@@ -27,29 +27,17 @@
 add_n_miss <- function(data, ..., label = "n_miss"){
 
   if (missing(...)) {
-    purrrlyr::by_row(.d = data,
-                     ..f = function(x) n_miss(x),
-                     .collate = "row",
-                     .to = paste0(label,"_all"))
+    data[[paste0(label, "_all")]] <- rowSums(is.na(data))
   } else {
 
     quo_vars <- rlang::quos(...)
 
     selected_data <- dplyr::select(data, !!!quo_vars)
 
-    prop_selected_data <- purrrlyr::by_row(.d = selected_data,
-                                           ..f = function(x) n_miss(x),
-                                           .collate = "row",
-                                           .to =  paste0(label,"_vars"))
-
-    # add only the variables prop_miss function, not the whole data.frame...
-    prop_selected_data_cut <- prop_selected_data %>%
-      dplyr::select(!!as.name(paste0(label,"_vars")))
-
-    dplyr::bind_cols(data, prop_selected_data_cut) %>% dplyr::as_tibble()
-
+    data[[paste0(label, "_vars")]] <- rowSums(is.na(selected_data))
   } # close else loop
 
+  data
 }
 
 #' Add column containing proportion of missing data values
@@ -98,26 +86,16 @@ add_n_miss <- function(data, ..., label = "n_miss"){
 add_prop_miss <- function(data, ..., label = "prop_miss"){
 
   if (missing(...)) {
-    purrrlyr::by_row(.d = data,
-                     ..f = function(x) (mean(is.na(x))),
-                     .collate = "row",
-                     .to = paste0(label,"_all"))
+    data[[paste0(label, "_all")]] <- rowMeans(is.na(data))
   } else {
 
     quo_vars <- rlang::quos(...)
 
     selected_data <- dplyr::select(data, !!!quo_vars)
 
-    prop_selected_data <- purrrlyr::by_row(.d = selected_data,
-                                           ..f = function(x) prop_miss(x),
-                                           .collate = "row",
-                                           .to =  paste0(label,"_vars"))
+    data[[paste0(label, "_vars")]] <- rowMeans(is.na(selected_data))
 
-    # add only the variables prop_miss function, not the whole data.frame...
-    prop_selected_data_cut <- prop_selected_data %>%
-      dplyr::select(!!as.name(paste0(label,"_vars")))
+  } # close else loop
 
-    dplyr::bind_cols(data, prop_selected_data_cut) %>% dplyr::as_tibble()
-
-  }
+  data
 }


### PR DESCRIPTION
This simplifies the code and is 4-5 orders of magnitude faster

<!--- Provide a general summary of your changes in the Title above -->

## Description
An alternative to https://github.com/njtierney/naniar/pull/111, in case you do not want the added complexity. This uses the base functions `rowSums()` and `rowMeans()` and the fact `is.na()` is vectorized to do the calculations. It is 4-5 orders of magnitude faster than the original implementation, and seems to be ~ 2-10x faster than the Rcpp version in that PR (although I did not directly compare them).

```r
microbenchmark::microbenchmark(add_n_miss(airquality), current_add_n_miss(airquality), unit = "ms")

#> Unit: milliseconds
#>                            expr       min         lq         mean     median          uq        max neval cld
#>          add_n_miss(airquality)  0.048766   0.060757   0.07926442   0.083558   0.0895555   0.160938   100  a
#>  current_add_n_miss(airquality) 92.369034 100.457525 106.24287966 104.383850 108.0468730 294.761924   100   b
```