### PR TITLE
Correct 'fill' aesthetic behavior in geom_miss_point() #137

### DIFF
--- a/R/stat-miss-point.R
+++ b/R/stat-miss-point.R
@@ -80,8 +80,7 @@ StatMissPoint <- ggproto("StatMissPoint", Stat,
     compute_group = function(data, scales) {
       missing_label <- label_miss_2d(data$x_miss, data$y_miss)
 
-      data.frame(x = data$x,
-                 y = data$y,
+      data.frame(data,
                  missing = missing_label)
 
       }


### PR DESCRIPTION
## Description
Using `fill = var` now works as expected in `geom_miss_point()`

## Related Issue
fix #137

## Tests
No tests included