### PR TITLE
Remove n miss cumsum

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: naniar
 Type: Package
 Title: Data Structures, Summaries, and Visualisations for Missing Data
-Version: 0.3.3.9000
+Version: 0.3.3.9100
 Authors@R: c(
   person("Nicholas", "Tierney", 
          role = c("aut", "cre"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,11 @@
+# naniar 0.3.3.9100 (2018/07/31)
+
+## New feature
+
+* `miss_var_summary` and `miss_case_summary` now no longer provide the 
+cumulative sum of missingness in the summaries - this summary can be added back
+to the data with the option `add_cumsum = TRUE`. #186
+
 # naniar 0.3.3.9000 (2018/07/30)
 
 ## Breaking Changes

--- a/R/add-cols.R
+++ b/R/add-cols.R
@@ -65,7 +65,9 @@ add_shadow_shift <- function(data, ..., suffix = "shift"){
     # change names
     names(shadow_shifted_df) <- paste0(names(shadow_shifted_df), "_", suffix)
 
-    tibble::as_tibble(dplyr::bind_cols(data, shadow_shifted_df))
+    return(
+      tibble::as_tibble(dplyr::bind_cols(data, shadow_shifted_df))
+    )
 
   }
 
@@ -81,7 +83,9 @@ add_shadow_shift <- function(data, ..., suffix = "shift"){
   # change names
   names(shadow_shifted_df) <- paste0(names(shadow_shifted_df),"_",suffix)
 
-  tibble::as_tibble(dplyr::bind_cols(data, shadow_shifted_df))
+  return(
+    tibble::as_tibble(dplyr::bind_cols(data, shadow_shifted_df))
+  )
 
 }
 
@@ -141,7 +145,9 @@ add_any_miss <- function(data, ..., label = "any_miss"){
 
     names(stub_data_label) <- paste0(label,"_all")
 
+    return(
     dplyr::bind_cols(data, stub_data_label) %>% tibble::as_tibble()
+    )
 
   }
 
@@ -159,7 +165,9 @@ add_any_miss <- function(data, ..., label = "any_miss"){
 
   names(stub_data_label) <- paste0(label,"_vars")
 
+  return(
   dplyr::bind_cols(data, stub_data_label) %>% tibble::as_tibble()
+  )
 
 }
 

--- a/R/add-n-prop-miss.R
+++ b/R/add-n-prop-miss.R
@@ -30,6 +30,8 @@ add_n_miss <- function(data, ..., label = "n_miss"){
 
   if (missing(...)) {
     data[[paste0(label, "_all")]] <- n_miss_row(data)
+
+    return(data)
   }
 
   quo_vars <- rlang::quos(...)
@@ -38,7 +40,7 @@ add_n_miss <- function(data, ..., label = "n_miss"){
 
   data[[paste0(label, "_vars")]] <- n_miss_row(selected_data)
 
-  data
+  return(data)
 }
 
 #' Add column containing proportion of missing data values
@@ -90,6 +92,8 @@ add_prop_miss <- function(data, ..., label = "prop_miss"){
 
   if (missing(...)) {
     data[[paste0(label, "_all")]] <- prop_miss_row(data)
+
+    return(data)
   }
 
   quo_vars <- rlang::quos(...)
@@ -98,5 +102,6 @@ add_prop_miss <- function(data, ..., label = "prop_miss"){
 
   data[[paste0(label, "_vars")]] <- prop_miss_row(selected_data)
 
-  data
+  return(data)
+
 }

--- a/R/miss-x-summary.R
+++ b/R/miss-x-summary.R
@@ -7,6 +7,10 @@
 #' @param data a data.frame
 #' @param order a logical indicating whether to order the result by `n_miss`.
 #'     Defaults to TRUE. If FALSE, order of variables is the order input.
+#' @param add_cumsum logical indicating whether or not to add the cumulative
+#'   sum of missings to the data. This can be useful when exploring patterns
+#'   of nonresponse. These are calculated as the cumulative sum of the missings
+#'   in the variables as they are first presented to the function.
 #' @param ... extra arguments
 #'
 #' @note `n_miss_cumsum` is calculated as the cumulative sum of missings in the
@@ -31,7 +35,10 @@
 #'   miss_var_summary()
 #'
 #' @export
-miss_var_summary <- function(data, order = FALSE, ...) {
+miss_var_summary <- function(data,
+                             order = FALSE,
+                             add_cumsum = FALSE,
+                             ...) {
 
   test_if_null(data)
 
@@ -41,11 +48,19 @@ miss_var_summary <- function(data, order = FALSE, ...) {
 }
 
 #' @export
-miss_var_summary.default <- function(data, order = TRUE, ...) {
+miss_var_summary.default <- function(data,
+                                     order = TRUE,
+                                     add_cumsum = FALSE,
+                                     ...) {
+
   res <- purrr::map_df(data, n_miss) %>%
     tidyr::gather(key = "variable", value = "n_miss") %>%
-    dplyr::mutate(pct_miss = (n_miss / nrow(data) * 100),
-                  n_miss_cumsum = cumsum(n_miss))
+    dplyr::mutate(pct_miss = (n_miss / nrow(data) * 100))
+
+  if (add_cumsum) {
+   res <- res %>% dplyr::mutate(n_miss_cumsum = cumsum(n_miss))
+  }
+
   if (order) {
     return(dplyr::arrange(res, -n_miss))
   }
@@ -56,9 +71,15 @@ miss_var_summary.default <- function(data, order = TRUE, ...) {
 }
 
 #' @export
-miss_var_summary.grouped_df <- function(data, order = TRUE, ...) {
+miss_var_summary.grouped_df <- function(data,
+                                        order = TRUE,
+                                        add_cumsum = FALSE,
+                                        ...) {
 
-  group_by_fun(data, .fun = miss_var_summary, order = order)
+  group_by_fun(data,
+               .fun = miss_var_summary,
+               order = order,
+               add_cumsum = add_cumsum)
 
 }
 
@@ -72,10 +93,10 @@ miss_var_summary.grouped_df <- function(data, order = TRUE, ...) {
 #' @param order a logical indicating whether or not to order the result by
 #'     n_miss. Defaults to TRUE. If FALSE, order of cases is the order input.
 #' @param ... extra arguments
-#'
-#' @note `n_miss_cumsum` is calculated as the cumulative sum of missings in the
-#'     variables in the order that they are given in the data when entering
-#'     the function
+#' @param add_cumsum logical indicating whether or not to add the cumulative
+#'   sum of missings to the data. This can be useful when exploring patterns
+#'   of nonresponse. These are calculated as the cumulative sum of the missings
+#'   in the variables as they are first presented to the function.
 #'
 #' @return a tibble of the percent of missing data in each case.
 #'
@@ -93,7 +114,10 @@ miss_var_summary.grouped_df <- function(data, order = TRUE, ...) {
 #'
 #' miss_case_summary(airquality)
 #'
-miss_case_summary <- function(data, order = TRUE, ...){
+miss_case_summary <- function(data,
+                              order = TRUE,
+                              add_cumsum = FALSE,
+                              ...){
 
   test_if_null(data)
 
@@ -103,35 +127,56 @@ miss_case_summary <- function(data, order = TRUE, ...){
 }
 
 #' @export
-miss_case_summary.default <- function(data, order = TRUE, ...){
+miss_case_summary.default <- function(data,
+                                      order = TRUE,
+                                      add_cumsum = FALSE,
+                                      ...){
 
   res <- data
 
   res[["pct_miss"]] <- rowMeans(is.na(res))*100
   res[["n_miss"]] <- as.integer(rowSums(is.na(res)))
   res[["case"]] <- seq_len(nrow(res))
-  res[["n_miss_cumsum"]] <- cumsum(res[["n_miss"]])
 
-  res <- dplyr::as_tibble(res)
+  if (add_cumsum) {
+    res[["n_miss_cumsum"]] <- cumsum(res[["n_miss"]])
+    res <- dplyr::as_tibble(res)
+    res <- dplyr::select(res,
+                         case,
+                         n_miss,
+                         pct_miss,
+                         n_miss_cumsum)
+  }
 
-  res <- dplyr::select(res,
-                       case,
-                       n_miss,
-                       pct_miss,
-                       n_miss_cumsum)
+  if (!add_cumsum) {
+    res <- dplyr::as_tibble(res)
+
+    res <- dplyr::select(res,
+                         case,
+                         n_miss,
+                         pct_miss)
+
+  }
 
   if (order) {
     return(dplyr::arrange(res, -n_miss))
   }
 
-  return(res)
-
+  if (!order) {
+    return(res)
+  }
 }
 
 #' @export
-miss_case_summary.grouped_df <- function(data, order = TRUE, ...){
+miss_case_summary.grouped_df <- function(data,
+                                         order = TRUE,
+                                         add_cumsum = FALSE,
+                                         ...){
 
-  group_by_fun(data, .fun = miss_case_summary, order = order)
+  group_by_fun(data,
+               .fun = miss_case_summary,
+               order = order,
+               add_cumsum = add_cumsum)
 
 }
 

--- a/R/shadows.R
+++ b/R/shadows.R
@@ -125,7 +125,9 @@ bind_shadow <- function(data, only_miss = FALSE){
 
     shadow_vars <- dplyr::select(data, !!!miss_vars) %>% as_shadow()
 
-    tibble::as_tibble(dplyr::bind_cols(data, shadow_vars))
+    return(
+      tibble::as_tibble(dplyr::bind_cols(data, shadow_vars))
+    )
 
   # if you want All the values to be added (the default behaviour)
   }
@@ -136,7 +138,9 @@ bind_shadow <- function(data, only_miss = FALSE){
 
     bound_shadow <- dplyr::bind_cols(data, data_shadow)
 
+    return(
     tibble::as_tibble(bound_shadow)
+    )
 
   }
 

--- a/man/miss_case_summary.Rd
+++ b/man/miss_case_summary.Rd
@@ -4,13 +4,18 @@
 \alias{miss_case_summary}
 \title{Summarise the missingness in each case}
 \usage{
-miss_case_summary(data, order = TRUE, ...)
+miss_case_summary(data, order = TRUE, add_cumsum = FALSE, ...)
 }
 \arguments{
 \item{data}{a data.frame}
 
 \item{order}{a logical indicating whether or not to order the result by
 n_miss. Defaults to TRUE. If FALSE, order of cases is the order input.}
+
+\item{add_cumsum}{logical indicating whether or not to add the cumulative
+sum of missings to the data. This can be useful when exploring patterns
+of nonresponse. These are calculated as the cumulative sum of the missings
+in the variables as they are first presented to the function.}
 
 \item{...}{extra arguments}
 }
@@ -21,11 +26,6 @@ a tibble of the percent of missing data in each case.
 Provide a summary for each case in the data of the number, percent missings,
 and cumulative sum of missings of the order of the variables. By default,
 it orders by the most missings in each variable.
-}
-\note{
-\code{n_miss_cumsum} is calculated as the cumulative sum of missings in the
-variables in the order that they are given in the data when entering
-the function
 }
 \examples{
 

--- a/man/miss_var_summary.Rd
+++ b/man/miss_var_summary.Rd
@@ -4,13 +4,18 @@
 \alias{miss_var_summary}
 \title{Summarise the missingness in each variable}
 \usage{
-miss_var_summary(data, order = FALSE, ...)
+miss_var_summary(data, order = FALSE, add_cumsum = FALSE, ...)
 }
 \arguments{
 \item{data}{a data.frame}
 
 \item{order}{a logical indicating whether to order the result by \code{n_miss}.
 Defaults to TRUE. If FALSE, order of variables is the order input.}
+
+\item{add_cumsum}{logical indicating whether or not to add the cumulative
+sum of missings to the data. This can be useful when exploring patterns
+of nonresponse. These are calculated as the cumulative sum of the missings
+in the variables as they are first presented to the function.}
 
 \item{...}{extra arguments}
 }

--- a/tests/testthat/test-miss-case-summary.R
+++ b/tests/testthat/test-miss-case-summary.R
@@ -23,14 +23,24 @@ test_that("miss_case_summary on grouped_df returns a tibble", {
   expect_is(miss_case_summary(aq_group), "tbl_df")
 })
 
-test_that("grouped_df returns 1 more column than regular miss_case_summary", {
+test_that("miss_case_summary produces the right number of columns", {
+  expect_equal(ncol(miss_case_summary(airquality)),
+               3)
+})
+
+test_that("miss_case_summary grouped produces the right number of columns", {
   expect_equal(ncol(miss_case_summary(aq_group)),
-                   ncol(miss_case_summary(airquality))+1)
+               4)
+})
+
+test_that("grouped_df returns the same number of columns as regular miss_case_summary", {
+  expect_equal(ncol(miss_case_summary(aq_group)),
+               ncol(miss_case_summary(airquality)) + 1)
 })
 
 test_that("grouped_df returns a column named 'Month'", {
   expect_identical(names(miss_case_summary(aq_group)),
-                   c("Month", "case", "n_miss","pct_miss", "n_miss_cumsum"))
+                   c("Month", "case", "n_miss","pct_miss"))
 })
 
 test_that("grouped_df returns a column named 'Month' with the right levels", {
@@ -38,3 +48,14 @@ test_that("grouped_df returns a column named 'Month' with the right levels", {
                    5:9)
 })
 
+# add testing for cumulative sum ----------------------------------------------
+
+test_that("miss_case_summary adds cumsum when add_cumsum = TRUE", {
+  expect_equal(names(miss_case_summary(airquality, add_cumsum = TRUE)),
+               c("case", "n_miss", "pct_miss", "n_miss_cumsum"))
+})
+
+test_that("miss_case_summary grouped adds cumsum when add_cumsum = TRUE", {
+  expect_equal(names(miss_case_summary(aq_group, add_cumsum = TRUE)),
+               c("Month", "case", "n_miss", "pct_miss", "n_miss_cumsum"))
+})

--- a/tests/testthat/test-miss-var-summary.R
+++ b/tests/testthat/test-miss-var-summary.R
@@ -22,14 +22,24 @@ test_that("miss_var_summary grouped_df returns a tibble", {
   expect_is(miss_var_summary(aq_group), "tbl_df")
 })
 
+test_that("miss_var_summary returns the right number of columns", {
+  expect_equal(ncol(miss_var_summary(airquality)),
+               3)
+})
+
+test_that("miss_var_summary group returns the right number of columns", {
+  expect_equal(ncol(miss_var_summary(aq_group)),
+               4)
+})
+
 test_that("grouped_df returns 1 more column than regular miss_var_summary", {
   expect_equal(ncol(miss_var_summary(aq_group)),
-               ncol(miss_var_summary(airquality))+1)
+               ncol(miss_var_summary(airquality)) + 1)
 })
 
 test_that("grouped_df returns a column named 'Month'", {
   expect_identical(names(miss_var_summary(aq_group)),
-                   c("Month", "variable", "n_miss","pct_miss", "n_miss_cumsum"))
+                   c("Month", "variable", "n_miss","pct_miss"))
 })
 
 test_that("grouped_df returns a dataframe with more rows than regular", {
@@ -42,3 +52,16 @@ test_that("grouped_df returns a column named 'Month' with the right levels", {
                    5:9)
 })
 
+
+
+# add testing for cumulative sum ----------------------------------------------
+
+test_that("miss_var_summary adds cumsum when add_cumsum = TRUE", {
+  expect_equal(names(miss_var_summary(airquality, add_cumsum = TRUE)),
+               c("variable", "n_miss", "pct_miss", "n_miss_cumsum"))
+})
+
+test_that("miss_var_summary grouped adds cumsum when add_cumsum = TRUE", {
+  expect_equal(names(miss_var_summary(aq_group, add_cumsum = TRUE)),
+               c("Month", "variable", "n_miss", "pct_miss", "n_miss_cumsum"))
+})


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

This change means that the cumulative sum of missings across variables and cases is now not included by default into the missingness summary.

## Related Issue
<!--- if this closes an issue make sure include e.g., "fix #4"
or similar - or if just relates to an issue make sure to mention
it like "#4" -->

Fixes #186

## Example
<!--- if introducing a new feature or changing behavior of existing
methods/functions, include an example if possible to do in brief form -->

``` r
library(naniar)
miss_var_summary(airquality)
#> # A tibble: 6 x 3
#>   variable n_miss pct_miss
#>   <chr>     <int>    <dbl>
#> 1 Ozone        37    24.2 
#> 2 Solar.R       7     4.58
#> 3 Wind          0     0   
#> 4 Temp          0     0   
#> 5 Month         0     0   
#> 6 Day           0     0
miss_var_summary(airquality, add_cumsum = TRUE)
#> # A tibble: 6 x 4
#>   variable n_miss pct_miss n_miss_cumsum
#>   <chr>     <int>    <dbl>         <int>
#> 1 Ozone        37    24.2             37
#> 2 Solar.R       7     4.58            44
#> 3 Wind          0     0               44
#> 4 Temp          0     0               44
#> 5 Month         0     0               44
#> 6 Day           0     0               44
miss_case_summary(airquality)
#> # A tibble: 153 x 3
#>     case n_miss pct_miss
#>    <int>  <int>    <dbl>
#>  1     5      2     33.3
#>  2    27      2     33.3
#>  3     6      1     16.7
#>  4    10      1     16.7
#>  5    11      1     16.7
#>  6    25      1     16.7
#>  7    26      1     16.7
#>  8    32      1     16.7
#>  9    33      1     16.7
#> 10    34      1     16.7
#> # ... with 143 more rows
miss_case_summary(airquality, add_cumsum = TRUE)
#> # A tibble: 153 x 4
#>     case n_miss pct_miss n_miss_cumsum
#>    <int>  <int>    <dbl>         <int>
#>  1     5      2     33.3             2
#>  2    27      2     33.3             9
#>  3     6      1     16.7             3
#>  4    10      1     16.7             4
#>  5    11      1     16.7             5
#>  6    25      1     16.7             6
#>  7    26      1     16.7             7
#>  8    32      1     16.7            10
#>  9    33      1     16.7            11
#> 10    34      1     16.7            12
#> # ... with 143 more rows
```

Created on 2018-07-31 by the [reprex package](http://reprex.tidyverse.org) (v0.2.0).

## Tests
<!--- Did you remember to include tests? Unless you're just changing
grammar, please include new tests for your change -->

Yes, tests have been included

## NEWS + DESCRIPTION
<!--- If you added a new feature or changed behaviour, describe the new/changed behaviour in the NEWS.md file. If it is a new feature, please bump the version in the DESCRIPTION and NEWS.md files  -->

Yes