### PR TITLE
Refactor capture of arguments

### DIFF
--- a/R/add-cols.R
+++ b/R/add-cols.R
@@ -23,10 +23,7 @@ add_shadow <- function(data, ...){
   if (missing(...)) {
     stop("No variables specified - please include variables to be selected")
   }
-
-  quo_vars <- rlang::quos(...)
-
-  shadow_df <- dplyr::select(data, !!!quo_vars) %>% as_shadow()
+  shadow_df <- dplyr::select(data, ...) %>% as_shadow()
 
   dplyr::bind_cols(data, shadow_df) %>% dplyr::as_tibble()
 
@@ -72,9 +69,7 @@ add_shadow_shift <- function(data, ..., suffix = "shift"){
   }
 
   # select variables
-  quo_vars <- rlang::quos(...)
-
-  shadow_shifted_vars <- dplyr::select(data, !!!quo_vars)
+  shadow_shifted_vars <- dplyr::select(data, ...)
 
   # shadow shift all (using purrr:map_df)
   # would be good to have a way of indicating that no shift was taken at all
@@ -156,11 +151,7 @@ add_any_miss <- function(data, ...,
 
   }
 
-  if (!missing(...)) {
-
-  quo_vars <- rlang::quos(...)
-
-  stub_data <- dplyr::select(data, !!!quo_vars)
+  stub_data <- dplyr::select(data, ...)
 
   stub_data_label <- stub_data %>%
     dplyr::mutate(.temp = any_row_miss(stub_data),
@@ -172,12 +163,7 @@ add_any_miss <- function(data, ...,
 
   names(stub_data_label) <- paste0(label,"_vars")
 
-  return(
   dplyr::bind_cols(data, stub_data_label) %>% tibble::as_tibble()
-  )
-
-  }
-
 }
 
 #' Is there a missing value in the row of a dataframe?
@@ -224,9 +210,7 @@ label_missings <- function(data,
   }
 
   if (!missing(...)) {
-    quo_vars <- rlang::quos(...)
-
-    data <- dplyr::select(data, !!!quo_vars)
+    data <- dplyr::select(data, ...)
   }
 
   temp <- any_row_na(data)
@@ -266,21 +250,11 @@ add_label_missings <- function(data,
   #   dplyr::mutate(any_missing = label_missings(.)) %>%
   #   dplyr::as_tibble()
 
-  if (missing(...)) {
-    updated_data <- data %>%
-      dplyr::mutate(any_missing = label_missings(.,
-                                                 missing = missing,
-                                                 complete = complete))
-  }
-
-  if (!missing(...)) {
-    quo_vars <- rlang::quos(...)
-    updated_data <- data %>%
-      dplyr::mutate(any_missing = label_missings(.,
-                                                 !!!quo_vars,
-                                                 missing = missing,
-                                                 complete = complete))
-  }
+  updated_data <- data %>%
+    dplyr::mutate(any_missing = label_missings(.,
+                                               ...,
+                                               missing = missing,
+                                               complete = complete))
 
 
   return(tibble::as_tibble(updated_data))
@@ -314,11 +288,9 @@ label_shadow <- function(data,
   }
 
   if (!missing(...)) {
-    quo_vars <- rlang::quos(...)
+    shadow_vars <- quo_to_shade(...)
 
-    shadow_vars <- quo_to_shade(!!!quo_vars)
-
-    data <- dplyr::select(data, !!!quo_vars, !!!shadow_vars)
+    data <- dplyr::select(data, ..., !!!shadow_vars)
   }
 
   temp <- any_row_shade(data)
@@ -363,21 +335,11 @@ add_label_shadow <- function(data,
                  created by `shade()`, `as_shadow()`, or `bind_shadow()`")
   }
 
-  if (missing(...)) {
-    updated_data <- data %>%
+  updated_data <- data %>%
     dplyr::mutate(any_missing = label_shadow(.,
+                                             ...,
                                              missing = missing,
                                              complete = complete))
-  }
-
-  if (!missing(...)) {
-    quo_vars <- rlang::quos(...)
-    updated_data <- data %>%
-      dplyr::mutate(any_missing = label_shadow(.,
-                                               !!!quo_vars,
-                                               missing = missing,
-                                               complete = complete))
-  }
 
 
   return(updated_data)

--- a/R/add-n-prop-miss.R
+++ b/R/add-n-prop-miss.R
@@ -34,9 +34,7 @@ add_n_miss <- function(data, ..., label = "n_miss"){
     return(data)
   }
 
-  quo_vars <- rlang::quos(...)
-
-  selected_data <- dplyr::select(data, !!!quo_vars)
+  selected_data <- dplyr::select(data, ...)
 
   data[[paste0(label, "_vars")]] <- n_miss_row(selected_data)
 
@@ -96,9 +94,7 @@ add_prop_miss <- function(data, ..., label = "prop_miss"){
     return(data)
   }
 
-  quo_vars <- rlang::quos(...)
-
-  selected_data <- dplyr::select(data, !!!quo_vars)
+  selected_data <- dplyr::select(data, ...)
 
   data[[paste0(label, "_vars")]] <- prop_miss_row(selected_data)
 

--- a/R/cast-shadows.R
+++ b/R/cast-shadows.R
@@ -40,11 +40,9 @@ cast_shadow <- function(data, ...){
 
   }
 
-    quo_vars <- rlang::quos(...)
+    shadow_vars <- dplyr::select(data, ...) %>% as_shadow()
 
-    shadow_vars <- dplyr::select(data, !!!quo_vars) %>% as_shadow()
-
-    my_data <- dplyr::select(data, !!!quo_vars)
+    my_data <- dplyr::select(data, ...)
 
     tibble::as_tibble(dplyr::bind_cols(my_data, shadow_vars))
 
@@ -74,9 +72,7 @@ cast_shadow <- function(data, ...){
 #'
 cast_shadow_shift <- function(data, ...){
 
-  quo_vars <- rlang::quos(...)
-
-  shadow_vars <- dplyr::select(data, !!!quo_vars) %>% cast_shadow(...)
+  shadow_vars <- dplyr::select(data, ...) %>% cast_shadow(...)
 
   # shift those values selected
   add_shadow_shift(shadow_vars, ...)
@@ -118,9 +114,7 @@ cast_shadow_shift_label <- function(data, ...){
     stop("please include variables to be selected after the data")
   }
 
-  quo_vars <- rlang::quos(...)
-
-  shadow_vars <- dplyr::select(data, !!!quo_vars) %>% cast_shadow(...)
+  shadow_vars <- dplyr::select(data, ...) %>% cast_shadow(...)
 
   # shift those values selected
   add_shadow_shift(shadow_vars, ...) %>% add_label_missings()

--- a/R/shadow-recode.R
+++ b/R/shadow-recode.R
@@ -181,8 +181,6 @@ recode_shadow <- function(data, ...){
   test_if_null(data)
   test_if_any_shade(data)
 
-  quo_var <- rlang::quos(...)
-
   formulas <- rlang::dots_list(...)
 
   condition <- formulas %>% purrr::map("condition")
@@ -191,7 +189,7 @@ recode_shadow <- function(data, ...){
 
   na_suffix <- purrr::map(suffix, ~ glue::glue("NA_{.x}"))
 
-  shadow_var <- rlang::syms(glue::glue("{names(quo_var)}_NA"))
+  shadow_var <- rlang::syms(glue::glue("{names(formulas)}_NA"))
 
   # build up the expressions to pass to case_when
   magic_shade_exprs <- purrr::pmap(

--- a/R/shadow-recode.R
+++ b/R/shadow-recode.R
@@ -206,7 +206,7 @@ recode_shadow <- function(data, ...){
                  na_suffix){
           rlang::expr(
             !!condition ~ factor(!!na_suffix,
-                                 levels = levels(.[[!!expr_text(shadow_var)]]))
+                                 levels = levels(.[[!!as_string(shadow_var)]]))
                  )
               }
          )
@@ -224,13 +224,13 @@ recode_shadow <- function(data, ...){
             dplyr::case_when(
               !!!cases,
               TRUE ~ factor(!!shadow_var,
-                            levels = levels(.[[!!expr_text(shadow_var)]]))
+                            levels = levels(.[[!!as_string(shadow_var)]]))
               ),
             class = c("shade", "factor")
             )
           )
         }) %>%
-    rlang::set_names(purrr::map_chr(shadow_var, expr_text))
+    rlang::set_names(purrr::map_chr(shadow_var, as_string))
 
   shadow_recoded <- data %>%
     update_shadow(unlist(suffix, use.names = FALSE)) %>%

--- a/R/shadows.R
+++ b/R/shadows.R
@@ -372,7 +372,7 @@ shadow_long <- function(shadow_data,
   }
 
   if (!missing(...)) {
-    vars <- bare_to_chr(...)
+    vars <- purrr::map(ensyms(...), as_string)
     gathered_df <- gathered_df %>%
       dplyr::filter(variable %in% vars)
   }

--- a/R/utils.R
+++ b/R/utils.R
@@ -195,24 +195,19 @@ add_span_counter <- function(data, span_size) {
 #' @return a list containing the levels of everything
 what_levels <- function(x) purrr::map(x, levels)
 
-# utility function to convert bare name to character
-bare_to_chr <- function(...){
-  ps <- rlang::exprs(...)
-
-  exprs_text <- function(ps) {
-    paste0(purrr::map_chr(ps, rlang::expr_text))
-  }
-
-  exprs_text(ps)
-
-}
-
 quo_to_shade <- function(...){
 
-  quo_vars <- rlang::quos(...)
+  # Use ensyms() rather than quos() because the latter allows
+  # arbitrary expressions. These variables are forwarded to select(),
+  # so potential expressions are `starts_with()`, `one_of()`, etc.
+  # The naniar code generally assumes that only symbols are passed in
+  # dots. `ensyms()` is a way of ensuring the input types.
+  vars <- rlang::ensyms(...)
 
-  shadow_chr <- bare_to_chr(!!!quo_vars) %>% paste0("_NA")
+  # Adding `_NA` suffix to user symbols
+  shadow_chr <- purrr::map(vars, as_string) %>% paste0("_NA")
 
+  # Casting back to symbols
   shadow_vars <- rlang::syms(shadow_chr)
 
   return(shadow_vars)


### PR DESCRIPTION
* Pass `...` directly to other functions rather than quote and splice.

* Use `as_string()` rather than `expr_text()` to cast symbols to strings. The latter is a multi-line deparser for arbitrary expressions. It might add backticks to deparsed symbols and allow unwanted input types like complex expressions.

* Use `ensyms()` before coercing to strings. This guarantees only symbols can be passed by user. `quos()` allows stuff like `starts_with()`, but the code generally assumes symbols, not calls.

* Remove `bare_to_chr()` as part of this refactoring. It was making the assumption that `exprs()` unwraps quosures, which was a bug in rlang. This causes a revdep failure for the upcoming rlang 0.3.0.