### PR TITLE
Use nrow argument in new_tibble()

### DIFF
--- a/R/nabular.R
+++ b/R/nabular.R
@@ -10,7 +10,7 @@ new_nabular <- function(x){
   if (sum(are_shade(x) == ncol(x)) | !any_shade(x)) {
     rlang::abort(message = "data must have shadow data with the regular data")
   }
-  tibble::new_tibble(x, subclass = "nabular")
+  tibble::new_tibble(x, subclass = "nabular", nrow = nrow(x))
 }
 
 #' Convert data into nabular form by binding shade to it

--- a/R/shadows.R
+++ b/R/shadows.R
@@ -165,9 +165,7 @@ bind_shadow <- function(data, only_miss = FALSE, ...){
 #' @return object with class "shadow", inheriting from it's original class
 #' @export
 new_shadow <- function(x){
-    # structure(x,
-    #           class = c("shadow", class(x)))
-    tibble::new_tibble(x, subclass = "shadow")
+  tibble::new_tibble(x, subclass = "shadow", nrow = nrow(x))
 }
 
 


### PR DESCRIPTION
This is required for the upcoming tibble 2.0.0 release.

I couldn't run the vdiffr tests.

CC @jennybc.