### PR TITLE
Changes after revdep checks of dplyr 0.8.0 RC

### DIFF
--- a/R/gg-miss-case.R
+++ b/R/gg-miss-case.R
@@ -41,7 +41,7 @@ gg_miss_case <- function(x, facet, order_cases = TRUE, show_pct = FALSE){
       x %>%
       miss_case_summary(order = TRUE) %>%
       # overwrite case
-      dplyr::mutate(case = 1:n()) %>%
+      dplyr::mutate(case = dplyr::row_number()) %>%
       gg_miss_case_create(show_pct = show_pct)
 
   }
@@ -60,7 +60,7 @@ gg_miss_case <- function(x, facet, order_cases = TRUE, show_pct = FALSE){
       dplyr::group_by(!!quo_group_by) %>%
       # overwrite case
       miss_case_summary(order = TRUE) %>%
-      dplyr::mutate(case = 1:n()) %>%
+      dplyr::mutate(case = dplyr::row_number()) %>%
       gg_miss_case_create(show_pct = show_pct) +
       facet_wrap(as.formula(paste("~", group_string)))
 

--- a/R/shadow-recode.R
+++ b/R/shadow-recode.R
@@ -82,7 +82,7 @@ shadow_expand_relevel <- function(.var, suffix){
 update_shadow <- function(data, suffix) {
 
   class_of_cols <- purrr::map(data,class)
-  class_of_data <- class(data)
+  attributes_of_data <- attributes(data)
 
   updated_shadow <-
   dplyr::mutate_if(.tbl = data,
@@ -96,9 +96,9 @@ update_shadow <- function(data, suffix) {
                                     class_of_cols,
                                     `class<-`)
 
-  structure(updated_shadow,
-            class = class_of_data)
+  attributes(updated_shadow) <- attributes_of_data
 
+  updated_shadow
 
 }
 


### PR DESCRIPTION
This fixes two problems that were identified as part of reverse dependency checks of dplyr 0.8.0 release candidate. 

  - `n()` must be imported or prefixed like any other function. In the PR, I've changed `1:n()` to `dplyr::row_number()` as `naniar` seems to prefix all `dplyr` functions. 

   - `update_shadow` was only restoring the class attributes, changed so that it restores all attributes, this was causing problems when data was a grouped_df. This likely was a problem before too, but dplyr 0.8.0 is stricter about what is a grouped data frame. 