### PR TITLE
Differentiate variables with no missing data in `gg_miss_var.`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: naniar
 Type: Package
 Title: Data Structures, Summaries, and Visualisations for Missing Data
-Version: 0.4.2
+Version: 0.4.2.9000
 Authors@R: c(
   person("Nicholas", "Tierney", 
          role = c("aut", "cre"),
@@ -50,7 +50,8 @@ Suggests:
     imputeTS,
     gdtools,
     Hmisc,
-    spelling
+    spelling,
+    scales
 VignetteBuilder: knitr
 Depends:
     R (>= 3.1.2)
@@ -125,3 +126,4 @@ Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 6.1.1
 Language: en-US
+Date: 2019-02-15

--- a/man/gg_miss_var.Rd
+++ b/man/gg_miss_var.Rd
@@ -15,7 +15,9 @@ gg_miss_var(x, facet, show_pct = FALSE)
 TRUE, it will display the proportion of missings.}
 }
 \value{
-a ggplot object depicting the number of missings in a given column
+a ggplot object depicting the number of missings in a given column.
+Variables with no missing data are drawn with a diamond shape and green color whereas
+variables with missing data are drawn with a circle shape and blue color.
 }
 \description{
 This is a visual analogue to \code{miss_var_summary}. It draws a ggplot of the
@@ -31,6 +33,15 @@ gg_miss_var(airquality) + labs(y = "Look at all the missing ones")
 gg_miss_var(airquality, Month)
 gg_miss_var(airquality, Month, show_pct = TRUE)
 gg_miss_var(airquality, Month, show_pct = TRUE) + ylim(0, 100)
+
+# A little more complex example
+n <- nrow(airquality)
+gg_miss_var(airquality) +
+  geom_text(aes(label = glue::glue("{n_miss}\\n({scales::percent(n_miss / n)})")),
+                nudge_y = 2) +
+  scale_y_continuous(sec.axis = sec_axis(trans = ~ ./n,
+                                         labels = scales::percent,
+                                         name = percent_missing))
 
 }
 \seealso{


### PR DESCRIPTION
## Description

For some large datasets with few missing data, it is hard to distinguish if missing data are present or not using `gg_miss_var`.
This commit add a change in shape and color for variables with no missing data at all and variables with missing data.
Some more complex examples of `gg_miss_var` have been provided

## Example

``` r
library(dplyr)
#> 
#> Attachement du package : 'dplyr'
#> The following objects are masked from 'package:stats':
#> 
#>     filter, lag
#> The following objects are masked from 'package:base':
#> 
#>     intersect, setdiff, setequal, union
library(naniar)
dummy <- tibble(
    x = rep(1, 1000), 
    y = c(NA, rep(1, 999)), 
    z = sample(c(1, NA), 1000, replace = TRUE)
)
gg_miss_var(dummy)
```

![](https://i.imgur.com/LaKeR3j.png)

<sup>Created on 2019-02-18 by the [reprex package](https://reprex.tidyverse.org) (v0.2.1)</sup>

## Issue

Fix #167 