### PR TITLE
Addresses bug where the number of missings in a row is not calcu…

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: naniar
 Type: Package
 Title: Data Structures, Summaries, and Visualisations for Missing Data
-Version: 0.4.2.9001
+Version: 0.4.3.9000
 Authors@R: c(
   person("Nicholas", "Tierney", 
          role = c("aut", "cre"),
@@ -38,7 +38,7 @@ ByteCompile: TRUE
 Suggests:
     knitr,
     rmarkdown,
-    testthat,
+    testthat (>= 2.1.0),
     rpart,
     rpart.plot,
     covr,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# naniar 0.4.3.9000 (2019/10/21)
+
+## Big Fix
+
+- Address bug where the number of missings in a row is not calculated properly - see [238](https://github.com/njtierney/naniar/issues/238) and [232](https://github.com/njtierney/naniar/issues/232). The solution involved using rowSums(is.na(x)), which was 3 times faster.
+
 # naniar 0.4.2.9001 (2019/04/17)
 
 ## Minor Changs

--- a/R/prop-pct-var-case-miss-complete.R
+++ b/R/prop-pct-var-case-miss-complete.R
@@ -95,30 +95,13 @@ pct_complete_var <- function(data){
 #'
 prop_miss_case <- function(data){
   test_if_null(data)
-
   test_if_dataframe(data)
 
-  temp <- data %>%
-    # which rows are complete?
-    stats::complete.cases() %>%
-    mean()
+  # How many missings in each row?
+  n_miss_in_rows <- rowSums(is.na(data))
 
-  # Return 1 if temp is 1
-  # Prevent error when all the rows contain a NA and then mean is 1
-  # so (1 -1)*100 = 0, whereas function should return 1
-  if (temp == 1) {
-    return(1)
-  }
-
-  if (temp == 0) {
-    # Return 0 if temp is 0
-    # Prevent error when no row contains a NA and then mean is 0
-    # so (1 -0)*1 = 1, whereas function should return 0.
-    return(0)
-  }
-
-  return((1 - temp))
-
+  # What is the proportion of rows with any missings?
+  mean(n_miss_in_rows > 0)
 }
 
 #' @export

--- a/R/utils.R
+++ b/R/utils.R
@@ -217,3 +217,23 @@ quo_to_shade <- function(...){
 class_glue <- function(x){
   class(x) %>% glue::glue_collapse(sep = ", ", last = ", or ")
 }
+
+simple_names <- function(x){
+  paste0("x",ncol(seq_len(x)))
+}
+
+diag_na <- function(nrow = 5,
+                    ncol = 5){
+
+  dna <- diag(x = NA,
+              nrow = 4,
+              ncol = 4)
+  suppressMessages(
+  tibble::as_tibble(dna,
+                    .name_repair = "unique")) %>%
+    set_names(paste0("x",seq_len(ncol(.))))
+}
+
+
+
+

--- a/tests/testthat/test-prop-cases-not-zero.R
+++ b/tests/testthat/test-prop-cases-not-zero.R
@@ -1,0 +1,53 @@
+mdf <- data.frame(x = NA)
+
+test_that("prop missing / complete are 0 or 1 where there is one variable", {
+  expect_equal(prop_miss_case(mdf), 1)
+  expect_equal(n_case_complete(mdf), 0)
+  expect_equal(prop_complete_case(mdf), 0)
+})
+
+df_diag_na <- diag_na(10)
+
+test_that("prop missing / complete are 0 or 1 where no complete cases", {
+  expect_equal(prop_miss_case(df_diag_na), 1)
+  expect_equal(n_case_complete(df_diag_na), 0)
+  expect_equal(prop_complete_case(df_diag_na), 0)
+})
+
+# This tests against
+bad_air_quality <- tibble::tribble(
+  ~Ozone, ~Solar.R, ~Wind, ~Temp, ~Month, ~Day,
+  NA,      190,   7.4,    67,      5,    1,
+  36,       NA,     8,    72,      5,    2,
+  12,      149,    NA,    74,      5,    3,
+  18,      313,  11.5,    NA,      5,    4,
+  NA,       NA,  14.3,    56,     NA,    5,
+  28,       NA,  14.9,    66,      5,   NA,
+  NA,      190,   7.4,    67,      5,    1,
+  36,       NA,     8,    72,      5,    2,
+  12,      149,    NA,    74,      5,    3,
+  18,      313,  11.5,    NA,      5,    4,
+  NA,       NA,  14.3,    56,     NA,    5,
+  28,       NA,  14.9,    66,      5,   NA
+)
+
+library(dplyr)
+library(tibble)
+
+bad_na_df <- bad_air_quality %>%
+  summarise(n_missing = n_case_miss(.),
+            n_complete = n_case_complete(.),
+            prop_missing = prop_miss_case(.),
+            prop_complete = prop_complete_case(.))
+
+expected_bad_na_df <- tibble(
+  n_missing = 12L,
+  n_complete = 0L,
+  prop_complete = 0,
+  prop_missing = 1
+)
+
+test_that("prop_miss_case returns same as mean_",{
+  expect_equal(bad_na_df, expected_bad_na_df)
+})
+


### PR DESCRIPTION
… properly, resolves 238 and  232. Solution also made prop_miss_case 3 times faster.

## Description

Proportion of missings in a given case (row) had a line of code to protect against cases where there were all missings or some missings, but it had the logic reversed.

This was kind of hard to understand, so I wrote a new implementation using the `rowSums(is.na(x))` pattern, which in my mind is easier to understand than using `stats::complete.cases`. It is also 3 times faster, which is a nice bonus.

``` r
library(naniar)

# This tests against
bad_air_quality <- tibble::tribble(
  ~Ozone, ~Solar.R, ~Wind, ~Temp, ~Month, ~Day,
  NA,      190,   7.4,    67,      5,    1,
  36,       NA,     8,    72,      5,    2,
  12,      149,    NA,    74,      5,    3,
  18,      313,  11.5,    NA,      5,    4,
  NA,       NA,  14.3,    56,     NA,    5,
  28,       NA,  14.9,    66,      5,   NA,
  NA,      190,   7.4,    67,      5,    1,
  36,       NA,     8,    72,      5,    2,
  12,      149,    NA,    74,      5,    3,
  18,      313,  11.5,    NA,      5,    4,
  NA,       NA,  14.3,    56,     NA,    5,
  28,       NA,  14.9,    66,      5,   NA
)

old <- function(x){
  
  temp <- x %>%
    # which rows are complete?
    stats::complete.cases() %>%
    mean()
  
  # Return 1 if temp is 1
  # Prevent error when all the rows contain a NA and then mean is 1
  # so (1 -1)*100 = 0, whereas function should return 1
  if (temp == 1) {
    return(0)
  }
  
  if (temp == 1) {
    # Return 0 if temp is 0
    # Prevent error when no row contains a NA and then mean is 0
    # so (1 -0)*1 = 1, whereas function should return 0.
    return(0)
  }
  
  return((1 - temp))
  
}

bm1 <- bench::mark(
  old = old(bad_air_quality),
  new = prop_miss_case(bad_air_quality)
)

bench:::autoplot.bench_mark(bm1)
#> Loading required namespace: tidyr
```

![](https://i.imgur.com/aump1TU.png)

``` r

summary(bm1, relative = TRUE)
#> # A tibble: 2 x 6
#>   expression   min median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <dbl>  <dbl>     <dbl>     <dbl>    <dbl>
#> 1 old         3.19   3.20      1         2.21     1   
#> 2 new         1      1         3.36      1        1.18
```

<sup>Created on 2019-10-21 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>

## Related Issue
Closes #238 and #232

## Example

``` r
naniar::prop_miss_case(tibble::tibble(x = NA))
#> [1] 1
```

<sup>Created on 2019-10-21 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>

## Tests
Yes - see

## NEWS + DESCRIPTION

Yes - both.