### PR TITLE
Fixes for dplyr 1.0.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -60,7 +60,7 @@ Imports:
     ggplot2,
     purrr,
     tidyr,
-    tibble,
+    tibble (>= 2.0.0),
     magrittr,
     stats,
     visdat,

--- a/R/add-cols.R
+++ b/R/add-cols.R
@@ -25,8 +25,9 @@ add_shadow <- function(data, ...){
   }
   shadow_df <- dplyr::select(data, ...) %>% as_shadow()
 
-  dplyr::bind_cols(data, shadow_df) %>% dplyr::as_tibble()
-
+  data <- tibble::as_tibble(data)
+  shadow_df <- tibble::as_tibble(shadow_df)
+  dplyr::bind_cols(data, shadow_df)
 }
 
 #' Add a shadow shifted column to a dataset
@@ -62,10 +63,10 @@ add_shadow_shift <- function(data, ..., suffix = "shift"){
     # change names
     names(shadow_shifted_df) <- paste0(names(shadow_shifted_df), "_", suffix)
 
-    return(
-      tibble::as_tibble(dplyr::bind_cols(data, shadow_shifted_df))
-    )
+    data <- tibble::as_tibble(data)
+    shadow_shifted_df <- tibble::as_tibble(shadow_shifted_df)
 
+    return(dplyr::bind_cols(data, shadow_shifted_df))
   }
 
   # select variables
@@ -78,10 +79,10 @@ add_shadow_shift <- function(data, ..., suffix = "shift"){
   # change names
   names(shadow_shifted_df) <- paste0(names(shadow_shifted_df),"_",suffix)
 
-  return(
-    tibble::as_tibble(dplyr::bind_cols(data, shadow_shifted_df))
-  )
+  data <- tibble::as_tibble(data)
+  shadow_shifted_df <- tibble::as_tibble(shadow_shifted_df)
 
+  return(dplyr::bind_cols(data, shadow_shifted_df))
 }
 
 #' Add a column describing presence of any missing values

--- a/R/cast-shadows.R
+++ b/R/cast-shadows.R
@@ -40,12 +40,10 @@ cast_shadow <- function(data, ...){
 
   }
 
-    shadow_vars <- dplyr::select(data, ...) %>% as_shadow()
+    shadow_vars <- tibble::as_tibble(as_shadow(dplyr::select(data, ...)))
+    my_data <- tibble::as_tibble(dplyr::select(data, ...))
 
-    my_data <- dplyr::select(data, ...)
-
-    tibble::as_tibble(dplyr::bind_cols(my_data, shadow_vars))
-
+    dplyr::bind_cols(my_data, shadow_vars)
   }
 
 #' Add a shadow and a shadow_shift column to a dataset

--- a/R/nabular.R
+++ b/R/nabular.R
@@ -10,7 +10,7 @@ new_nabular <- function(x){
   if (sum(are_shade(x) == ncol(x)) | !any_shade(x)) {
     rlang::abort(message = "data must have shadow data with the regular data")
   }
-  tibble::new_tibble(x, subclass = "nabular", nrow = as.integer(nrow(x)))
+  tibble::new_tibble(x, class = "nabular", nrow = as.integer(nrow(x)))
 }
 
 #' Convert data into nabular form by binding shade to it

--- a/R/shadows.R
+++ b/R/shadows.R
@@ -183,7 +183,7 @@ bind_shadow <- function(data, only_miss = FALSE, ...){
 #' @return object with class "shadow", inheriting from it's original class
 #' @export
 new_shadow <- function(x){
-  tibble::new_tibble(x, subclass = "shadow", nrow = as.integer(nrow(x)))
+  tibble::new_tibble(x, class = "shadow", nrow = as.integer(nrow(x)))
 }
 
 

--- a/R/shadows.R
+++ b/R/shadows.R
@@ -143,9 +143,9 @@ bind_shadow <- function(data, only_miss = FALSE, ...){
     # I want to only select columns that contain a missing value.
     miss_vars <- rlang::syms(miss_var_which(data))
 
-    shadow_vars <- dplyr::select(data, !!!miss_vars) %>% as_shadow()
-
-    shadow_data <- tibble::as_tibble(dplyr::bind_cols(data, shadow_vars))
+    shadow_vars <- dplyr::as_tibble(as_shadow(dplyr::select(data, !!!miss_vars)))
+    data <- tibble::as_tibble(data)
+    shadow_data <- dplyr::bind_cols(data, shadow_vars)
 
     # class(shadow_data) <- c("shadow", class(shadow_data))
 
@@ -157,11 +157,9 @@ bind_shadow <- function(data, only_miss = FALSE, ...){
 
   if (!only_miss) {
 
-    data_shadow <- as_shadow(data)
-
-    bound_shadow <- dplyr::bind_cols(data, data_shadow)
-
-    shadow_data <- tibble::as_tibble(bound_shadow)
+    data_shadow <- tibble::as_tibble(as_shadow(data))
+    data <- tibble::as_tibble(data)
+    shadow_data <- dplyr::bind_cols(data, data_shadow)
 
     if (!missing(...)) {
       shadow_data <- shadow_data %>% recode_shadow(...)

--- a/tests/testthat/test-prop-cases-not-zero.R
+++ b/tests/testthat/test-prop-cases-not-zero.R
@@ -37,10 +37,12 @@ library(dplyr)
 library(tibble)
 
 bad_na_df <- bad_air_quality %>%
-  summarise(n_missing = n_case_miss(.),
-            n_complete = n_case_complete(.),
-            prop_missing = prop_miss_case(.),
-            prop_complete = prop_complete_case(.))
+  summarise(
+    n_missing = n_case_miss(.),
+    n_complete = n_case_complete(.),
+    prop_complete = prop_complete_case(.),
+    prop_missing = prop_miss_case(.),
+  )
 
 expected_bad_na_df <- tibble(
   n_missing = 12L,


### PR DESCRIPTION
No real big changes here — just one failing test because `all.equal.tbl_df` used to ignore column order.

But I also eliminate a bunch of warnings, mostly by coercing to tibble before binding, instead of after. I think this is generally more principled, and it certainly generates fewer warnings with dev vctrs.