### PR TITLE
Speed up miss var summary

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: naniar
 Type: Package
 Title: Data Structures, Summaries, and Visualisations for Missing Data
-Version: 0.5.1
+Version: 0.5.1.9000
 Authors@R: c(
   person("Nicholas", "Tierney", 
          role = c("aut", "cre"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,10 @@
+# naniar 0.5.1.9000
+
+## Minor Changes
+
+- Improved code in `miss_var_summary()`, `miss_var_table()`, and 
+ `prop_miss_var()`, improving speed.
+
 # naniar 0.5.1 (2020/04/10) "Uncle Andrew's Applewood Wardrobe"
 
 ## Minor Changes

--- a/R/miss-x-summary.R
+++ b/R/miss-x-summary.R
@@ -53,9 +53,12 @@ miss_var_summary.default <- function(data,
                                      add_cumsum = FALSE,
                                      ...) {
 
-  res <- purrr::map_dfc(data, n_miss) %>%
-    tidyr::gather(key = "variable", value = "n_miss") %>%
-    dplyr::mutate(pct_miss = (n_miss / nrow(data) * 100))
+  col_n_miss <- colSums(is.na(data))
+  col_pct_miss <- colMeans(is.na(data)) * 100
+
+  res <- tibble::tibble(variable = names(col_n_miss),
+                        n_miss = as.integer(col_n_miss),
+                        pct_miss = as.numeric(col_pct_miss))
 
   if (add_cumsum) {
    res <- res %>% dplyr::mutate(n_miss_cumsum = cumsum(n_miss))
@@ -66,7 +69,6 @@ miss_var_summary.default <- function(data,
   }
 
   return(res)
-
 
 }
 

--- a/R/miss-x-table.R
+++ b/R/miss-x-table.R
@@ -87,9 +87,9 @@ miss_var_table <- function(data){
 
 miss_var_table.default <- function(data){
 
-  purrr::map_dfc(data, ~n_miss(.)) %>%
-    tidyr::gather(key = "variable",
-                  value = "n_miss_in_var") %>%
+  miss_var_summary(data) %>%
+    dplyr::rename(n_miss_in_var = n_miss) %>%
+    dplyr::select(-pct_miss) %>%
     dplyr::group_by(n_miss_in_var) %>%
     dplyr::tally() %>%
     dplyr::rename(n_vars = n) %>%

--- a/R/prop-pct-var-case-miss-complete.R
+++ b/R/prop-pct-var-case-miss-complete.R
@@ -26,7 +26,7 @@ prop_miss_var <- function(data){
   test_if_dataframe(data)
 
   # find the proportion of variables that contain (any) missing values
-  mean(purrr::map_lgl(data, anyNA))
+  mean(colSums(is.na(data)) > 0)
 
 } # end function
 


### PR DESCRIPTION
## Description

Speeds up `miss_var_summary` by 3 times, using `colSums` approach.

## Related Issue

Related to #256 

## Example

Code behaves as previous

## Tests

Tests passed without issue

## NEWS + DESCRIPTION

NEWS bullet added, description bumped.