### PR TITLE
Shadow long error 314

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,7 +8,7 @@
 - `geom_miss_point()` works with `shape` argument #290
 - fix bug with `all_complete`, which was implemented as `!anyNA(x)` but should be `all(complete.cases(x))`.
 - correctly implement `any_na()` (and `any_miss()`) and `any_complete()`. Rework examples to demonstrate workflow for finding complete variables.
-- Fix bug with `shadow_long` not working when gathering variables of mixed type. Fix involves specifying a value transform, which defaults to character.
+- Fix bug with `shadow_long` not working when gathering variables of mixed type. Fix involves specifying a value transform, which defaults to character. #314
 
 ## Misc
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,7 @@
 - `geom_miss_point()` works with `shape` argument #290
 - fix bug with `all_complete`, which was implemented as `!anyNA(x)` but should be `all(complete.cases(x))`.
 - correctly implement `any_na()` (and `any_miss()`) and `any_complete()`. Rework examples to demonstrate workflow for finding complete variables.
+- Fix bug with `shadow_long` not working when gathering variables of mixed type. Fix involves specifying a value transform, which defaults to character.
 
 ## Misc
 

--- a/R/shadows.R
+++ b/R/shadows.R
@@ -208,6 +208,7 @@ gather_shadow <- function(data){
 #' shadow_long(aq_shadow, Ozone, Solar.R)
 #'
 #' # ensure `value` is numeric
+#' shadow_long(aq_shadow, fn_value_transform = as.numeric)
 #' shadow_long(aq_shadow, Ozone, Solar.R, fn_value_transform = as.numeric)
 #'
 #'

--- a/R/shadows.R
+++ b/R/shadows.R
@@ -216,7 +216,8 @@ shadow_long <- function(
     shadow_data,
     cols = -dplyr::one_of(shadow_data_names),
     names_to = "variable",
-    values_to = "value"
+    values_to = "value",
+    values_transform = list(value = as.character)
   )
 
   longer_one_shade_names <- names(which_are_shade(longer_one))

--- a/man/shadow_long.Rd
+++ b/man/shadow_long.Rd
@@ -4,12 +4,17 @@
 \alias{shadow_long}
 \title{Reshape shadow data into a long format}
 \usage{
-shadow_long(shadow_data, ..., only_main_vars = TRUE)
+shadow_long(shadow_data, ..., fn_value_transform = NULL, only_main_vars = TRUE)
 }
 \arguments{
 \item{shadow_data}{a data.frame}
 
 \item{...}{bare name of variables that you want to focus on}
+
+\item{fn_value_transform}{function to transform the "value" column. Default
+is NULL, which defaults to \code{as.character}. Be aware that \code{as.numeric} may
+fail for some instances if it cannot coerce the value into numeric. See
+the examples.}
 
 \item{only_main_vars}{logical - do you want to filter down to main variables?}
 }
@@ -18,11 +23,13 @@ data in long format, with columns \code{variable}, \code{value}, \code{variable_
 }
 \description{
 Once data is in \code{nabular} form, where the shadow is bound to the data, it
-can be useful to reshape it into a long format with the columns
+can be useful to reshape it into a long format with the shadow columns
+in a separate grouping - so you have \code{variable}, \code{value}, and
+\code{variable_NA} and \code{value_NA}.
 }
 \examples{
 
-aq_shadow <- bind_shadow(airquality)
+aq_shadow <- nabular(airquality)
 
 shadow_long(aq_shadow)
 
@@ -30,6 +37,9 @@ shadow_long(aq_shadow)
 shadow_long(aq_shadow, Ozone)
 
 shadow_long(aq_shadow, Ozone, Solar.R)
+
+# ensure `value` is numeric
+shadow_long(aq_shadow, Ozone, Solar.R, fn_value_transform = as.numeric)
 
 
 }

--- a/man/shadow_long.Rd
+++ b/man/shadow_long.Rd
@@ -39,6 +39,7 @@ shadow_long(aq_shadow, Ozone)
 shadow_long(aq_shadow, Ozone, Solar.R)
 
 # ensure `value` is numeric
+shadow_long(aq_shadow, fn_value_transform = as.numeric)
 shadow_long(aq_shadow, Ozone, Solar.R, fn_value_transform = as.numeric)
 
 

--- a/tests/testthat/_snaps/shadow-long.md
+++ b/tests/testthat/_snaps/shadow-long.md
@@ -1,0 +1,80 @@
+# shadow_long returns the right dimensions and names etc
+
+    Code
+      shadow_long(ocean_shadow)
+    Output
+      # A tibble: 5,888 x 4
+         variable   value        variable_NA   value_NA
+         <chr>      <chr>        <chr>         <fct>   
+       1 year       1997         year_NA       !NA     
+       2 latitude   0            latitude_NA   !NA     
+       3 longitude  -110         longitude_NA  !NA     
+       4 sea_temp_c 27.59000015  sea_temp_c_NA !NA     
+       5 air_temp_c 27.14999962  air_temp_c_NA !NA     
+       6 humidity   79.59999847  humidity_NA   !NA     
+       7 wind_ew    -6.400000095 wind_ew_NA    !NA     
+       8 wind_ns    5.400000095  wind_ns_NA    !NA     
+       9 year       1997         year_NA       !NA     
+      10 latitude   0            latitude_NA   !NA     
+      # i 5,878 more rows
+
+# shadow_long works gives the classes with function value transform
+
+    Code
+      shadow_long(ocean_shadow, fn_value_transform = as.numeric)
+    Output
+      # A tibble: 5,888 x 4
+         variable     value variable_NA   value_NA
+         <chr>        <dbl> <chr>         <fct>   
+       1 year       1997    year_NA       !NA     
+       2 latitude      0    latitude_NA   !NA     
+       3 longitude  -110    longitude_NA  !NA     
+       4 sea_temp_c   27.6  sea_temp_c_NA !NA     
+       5 air_temp_c   27.1  air_temp_c_NA !NA     
+       6 humidity     79.6  humidity_NA   !NA     
+       7 wind_ew      -6.40 wind_ew_NA    !NA     
+       8 wind_ns       5.40 wind_ns_NA    !NA     
+       9 year       1997    year_NA       !NA     
+      10 latitude      0    latitude_NA   !NA     
+      # i 5,878 more rows
+
+# shadow_long returns right dimensions, names, etc when filtered
+
+    Code
+      shadow_long(ocean_shadow, air_temp_c, humidity)
+    Output
+      # A tibble: 1,472 x 4
+         variable   value       variable_NA   value_NA
+         <chr>      <chr>       <chr>         <fct>   
+       1 air_temp_c 27.14999962 air_temp_c_NA !NA     
+       2 humidity   79.59999847 humidity_NA   !NA     
+       3 air_temp_c 27.02000046 air_temp_c_NA !NA     
+       4 humidity   75.80000305 humidity_NA   !NA     
+       5 air_temp_c 27          air_temp_c_NA !NA     
+       6 humidity   76.5        humidity_NA   !NA     
+       7 air_temp_c 26.93000031 air_temp_c_NA !NA     
+       8 humidity   76.19999695 humidity_NA   !NA     
+       9 air_temp_c 26.84000015 air_temp_c_NA !NA     
+      10 humidity   76.40000153 humidity_NA   !NA     
+      # i 1,462 more rows
+
+# shadow_long returns right dimensions, names, etc when filtered with function value transform
+
+    Code
+      shadow_long(ocean_shadow, air_temp_c, humidity, fn_value_transform = as.numeric)
+    Output
+      # A tibble: 1,472 x 4
+         variable   value variable_NA   value_NA
+         <chr>      <dbl> <chr>         <fct>   
+       1 air_temp_c  27.1 air_temp_c_NA !NA     
+       2 humidity    79.6 humidity_NA   !NA     
+       3 air_temp_c  27.0 air_temp_c_NA !NA     
+       4 humidity    75.8 humidity_NA   !NA     
+       5 air_temp_c  27   air_temp_c_NA !NA     
+       6 humidity    76.5 humidity_NA   !NA     
+       7 air_temp_c  26.9 air_temp_c_NA !NA     
+       8 humidity    76.2 humidity_NA   !NA     
+       9 air_temp_c  26.8 air_temp_c_NA !NA     
+      10 humidity    76.4 humidity_NA   !NA     
+      # i 1,462 more rows
+

--- a/tests/testthat/test-shadow-long.R
+++ b/tests/testthat/test-shadow-long.R
@@ -1,52 +1,30 @@
-aq_shadow <- nabular(airquality)
+ocean_shadow <- nabular(oceanbuoys)
 
-aq_sh_long <- shadow_long(aq_shadow)
-
-test_that("shadow_long returns data of the right dimensions", {
-  expect_equal(dim(aq_sh_long), c(918, 4))
+test_that("shadow_long returns the right dimensions and names etc", {
+  expect_snapshot(
+    shadow_long(ocean_shadow)
+  )
 })
 
-test_that("shadow_long returns data with the right names", {
-  expect_equal(names(aq_sh_long),
-               c("variable", "value", "variable_NA", "value_NA"))
-})
-library(purrr)
-
-test_that("shadow_long returns right data class", {
-  expect_equal(as.character(map_chr(aq_sh_long, class)),
-               c("character", "numeric", "character", "factor"))
+test_that("shadow_long works gives the classes with function value transform", {
+  expect_snapshot(
+    shadow_long(ocean_shadow,
+                fn_value_transform = as.numeric)
+  )
 })
 
-aq_sh_long_ozone <- shadow_long(aq_shadow, Ozone)
-
-test_that("shadow_long returns data with right dimensions when filtered", {
-  expect_equal(dim(aq_sh_long_ozone), c(153, 4))
+test_that("shadow_long returns right dimensions, names, etc when filtered", {
+  expect_snapshot(
+    shadow_long(ocean_shadow, air_temp_c, humidity)
+  )
 })
 
-test_that("shadow_long returns data with right names when filtered", {
-  expect_equal(names(aq_sh_long_ozone),
-               c("variable", "value", "variable_NA", "value_NA"))
+test_that("shadow_long returns right dimensions, names, etc when filtered with function value transform", {
+  expect_snapshot(
+    shadow_long(ocean_shadow,
+                air_temp_c,
+                humidity,
+                fn_value_transform = as.numeric
+  )
+  )
 })
-
-test_that("shadow_long returns right data class when filtered", {
-  expect_equal(as.character(map_chr(aq_sh_long_ozone, class)),
-               c("character", "numeric", "character", "factor"))
-})
-
-
-aq_sh_long_ozone_solar <- shadow_long(aq_shadow, Ozone, Solar.R)
-
-test_that("shadow_long returns data with right dimensions when filtered", {
-  expect_equal(dim(aq_sh_long_ozone_solar), c(306, 4))
-})
-
-test_that("shadow_long returns data with right names when filtered", {
-  expect_equal(names(aq_sh_long_ozone_solar),
-               c("variable", "value", "variable_NA", "value_NA"))
-})
-
-test_that("shadow_long returns right data class when filtered", {
-  expect_equal(as.character(map_chr(aq_sh_long_ozone_solar, class)),
-               c("character", "numeric", "character", "factor"))
-})
-


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Fix bug with `shadow_long` not working when gathering variables of mixed type. Fix involves specifying a value transform, which defaults to character. 

## Related Issue
<!--- if this closes an issue make sure include e.g., "fix #4"
or similar - or if just relates to an issue make sure to mention
it like "#4" -->

Resolves #314 

## Example
<!--- if introducing a new feature or changing behavior of existing
methods/functions, include an example if possible to do in brief form -->

``` r
library(naniar)
aq_shadow <- nabular(airquality)

shadow_long(aq_shadow)
#> # A tibble: 918 × 4
#>    variable value variable_NA value_NA
#>    <chr>    <chr> <chr>       <fct>   
#>  1 Ozone    41    Ozone_NA    !NA     
#>  2 Solar.R  190   Solar.R_NA  !NA     
#>  3 Wind     7.4   Wind_NA     !NA     
#>  4 Temp     67    Temp_NA     !NA     
#>  5 Month    5     Month_NA    !NA     
#>  6 Day      1     Day_NA      !NA     
#>  7 Ozone    36    Ozone_NA    !NA     
#>  8 Solar.R  118   Solar.R_NA  !NA     
#>  9 Wind     8     Wind_NA     !NA     
#> 10 Temp     72    Temp_NA     !NA     
#> # ℹ 908 more rows

# then filter only on Ozone and Solar.R
shadow_long(aq_shadow, Ozone, Solar.R)
#> # A tibble: 306 × 4
#>    variable value variable_NA value_NA
#>    <chr>    <chr> <chr>       <fct>   
#>  1 Ozone    41    Ozone_NA    !NA     
#>  2 Solar.R  190   Solar.R_NA  !NA     
#>  3 Ozone    36    Ozone_NA    !NA     
#>  4 Solar.R  118   Solar.R_NA  !NA     
#>  5 Ozone    12    Ozone_NA    !NA     
#>  6 Solar.R  149   Solar.R_NA  !NA     
#>  7 Ozone    18    Ozone_NA    !NA     
#>  8 Solar.R  313   Solar.R_NA  !NA     
#>  9 Ozone    <NA>  Ozone_NA    NA      
#> 10 Solar.R  <NA>  Solar.R_NA  NA      
#> # ℹ 296 more rows

# ensure `value` is numeric
shadow_long(aq_shadow, fn_value_transform = as.numeric)
#> # A tibble: 918 × 4
#>    variable value variable_NA value_NA
#>    <chr>    <dbl> <chr>       <fct>   
#>  1 Ozone     41   Ozone_NA    !NA     
#>  2 Solar.R  190   Solar.R_NA  !NA     
#>  3 Wind       7.4 Wind_NA     !NA     
#>  4 Temp      67   Temp_NA     !NA     
#>  5 Month      5   Month_NA    !NA     
#>  6 Day        1   Day_NA      !NA     
#>  7 Ozone     36   Ozone_NA    !NA     
#>  8 Solar.R  118   Solar.R_NA  !NA     
#>  9 Wind       8   Wind_NA     !NA     
#> 10 Temp      72   Temp_NA     !NA     
#> # ℹ 908 more rows
shadow_long(aq_shadow, Ozone, Solar.R, fn_value_transform = as.numeric)
#> # A tibble: 306 × 4
#>    variable value variable_NA value_NA
#>    <chr>    <dbl> <chr>       <fct>   
#>  1 Ozone       41 Ozone_NA    !NA     
#>  2 Solar.R    190 Solar.R_NA  !NA     
#>  3 Ozone       36 Ozone_NA    !NA     
#>  4 Solar.R    118 Solar.R_NA  !NA     
#>  5 Ozone       12 Ozone_NA    !NA     
#>  6 Solar.R    149 Solar.R_NA  !NA     
#>  7 Ozone       18 Ozone_NA    !NA     
#>  8 Solar.R    313 Solar.R_NA  !NA     
#>  9 Ozone       NA Ozone_NA    NA      
#> 10 Solar.R     NA Solar.R_NA  NA      
#> # ℹ 296 more rows
```

<sup>Created on 2023-05-01 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>

<details style="margin-bottom:10px;">
<summary>
Session info
</summary>

``` r
sessioninfo::session_info()
#> ─ Session info ───────────────────────────────────────────────────────────────
#>  setting  value
#>  version  R version 4.3.0 (2023-04-21)
#>  os       macOS Ventura 13.2
#>  system   aarch64, darwin20
#>  ui       X11
#>  language (EN)
#>  collate  en_US.UTF-8
#>  ctype    en_US.UTF-8
#>  tz       America/Los_Angeles
#>  date     2023-05-01
#>  pandoc   2.19.2 @ /Applications/RStudio.app/Contents/Resources/app/quarto/bin/tools/ (via rmarkdown)
#> 
#> ─ Packages ───────────────────────────────────────────────────────────────────
#>  package     * version    date (UTC) lib source
#>  cli           3.6.1      2023-03-23 [1] CRAN (R 4.3.0)
#>  colorspace    2.1-0      2023-01-23 [1] CRAN (R 4.3.0)
#>  digest        0.6.31     2022-12-11 [1] CRAN (R 4.3.0)
#>  dplyr         1.1.2      2023-04-20 [1] CRAN (R 4.3.0)
#>  evaluate      0.20       2023-01-17 [1] CRAN (R 4.3.0)
#>  fansi         1.0.4      2023-01-22 [1] CRAN (R 4.3.0)
#>  fastmap       1.1.1      2023-02-24 [1] CRAN (R 4.3.0)
#>  fs            1.6.2      2023-04-25 [1] CRAN (R 4.3.0)
#>  generics      0.1.3      2022-07-05 [1] CRAN (R 4.3.0)
#>  ggplot2       3.4.2      2023-04-03 [1] CRAN (R 4.3.0)
#>  glue          1.6.2      2022-02-24 [1] CRAN (R 4.3.0)
#>  gtable        0.3.3      2023-03-21 [1] CRAN (R 4.3.0)
#>  htmltools     0.5.5      2023-03-23 [1] CRAN (R 4.3.0)
#>  knitr         1.42       2023-01-25 [1] CRAN (R 4.3.0)
#>  lifecycle     1.0.3      2022-10-07 [1] CRAN (R 4.3.0)
#>  magrittr      2.0.3      2022-03-30 [1] CRAN (R 4.3.0)
#>  munsell       0.5.0      2018-06-12 [1] CRAN (R 4.3.0)
#>  naniar      * 1.0.0.9000 2023-05-01 [1] local
#>  pillar        1.9.0      2023-03-22 [1] CRAN (R 4.3.0)
#>  pkgconfig     2.0.3      2019-09-22 [1] CRAN (R 4.3.0)
#>  purrr         1.0.1      2023-01-10 [1] CRAN (R 4.3.0)
#>  R.cache       0.16.0     2022-07-21 [1] CRAN (R 4.3.0)
#>  R.methodsS3   1.8.2      2022-06-13 [1] CRAN (R 4.3.0)
#>  R.oo          1.25.0     2022-06-12 [1] CRAN (R 4.3.0)
#>  R.utils       2.12.2     2022-11-11 [1] CRAN (R 4.3.0)
#>  R6            2.5.1      2021-08-19 [1] CRAN (R 4.3.0)
#>  reprex        2.0.2      2022-08-17 [1] CRAN (R 4.3.0)
#>  rlang         1.1.0      2023-03-14 [1] CRAN (R 4.3.0)
#>  rmarkdown     2.21       2023-03-26 [1] CRAN (R 4.3.0)
#>  rstudioapi    0.14       2022-08-22 [1] CRAN (R 4.3.0)
#>  scales        1.2.1      2022-08-20 [1] CRAN (R 4.3.0)
#>  sessioninfo   1.2.2      2021-12-06 [1] CRAN (R 4.3.0)
#>  styler        1.9.1      2023-03-04 [1] CRAN (R 4.3.0)
#>  tibble        3.2.1      2023-03-20 [1] CRAN (R 4.3.0)
#>  tidyr         1.3.0      2023-01-24 [1] CRAN (R 4.3.0)
#>  tidyselect    1.2.0      2022-10-10 [1] CRAN (R 4.3.0)
#>  utf8          1.2.3      2023-01-31 [1] CRAN (R 4.3.0)
#>  vctrs         0.6.2      2023-04-19 [1] CRAN (R 4.3.0)
#>  visdat        0.6.0      2023-02-02 [1] CRAN (R 4.3.0)
#>  withr         2.5.0      2022-03-03 [1] CRAN (R 4.3.0)
#>  xfun          0.39       2023-04-20 [1] CRAN (R 4.3.0)
#>  yaml          2.3.7      2023-01-23 [1] CRAN (R 4.3.0)
#> 
#>  [1] /Library/Frameworks/R.framework/Versions/4.3-arm64/Resources/library
#> 
#> ──────────────────────────────────────────────────────────────────────────────
```

</details>

## Tests
<!--- Did you remember to include tests? Unless you're just changing
grammar, please include new tests for your change -->

Yes

## NEWS + DESCRIPTION
<!--- If you added a new feature or changed behaviour, describe the new/changed behaviour in the NEWS.md file. If it is a new feature, please bump the version in the DESCRIPTION and NEWS.md files  -->

Yes
