### PR TITLE
soft deprecate miss_case_cumsum and miss_var_cumsum; resolves #257

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -19,6 +19,7 @@
 ## Changes
 
 - soft deprecated `shadow_shift` - #193
+- soft deprecate miss_case_cumsum and miss_var_cumsum - #257
 
 # naniar 1.0.0
 

--- a/R/gg-miss-case-cumsum.R
+++ b/R/gg-miss-case-cumsum.R
@@ -19,7 +19,7 @@
 gg_miss_case_cumsum <- function(x, breaks = 20){
 
   ggobject <- x %>%
-    miss_case_cumsum() %>%
+    miss_case_summary(add_cumsum = TRUE) %>%
     ggplot(aes(x = stats::reorder(case, n_miss_cumsum),
                y = n_miss_cumsum,
                group = 1)) +

--- a/R/gg-miss-var-cumsum.R
+++ b/R/gg-miss-var-cumsum.R
@@ -19,7 +19,7 @@
 gg_miss_var_cumsum <- function(x){
 
   ggobject <- x %>%
-    miss_var_cumsum() %>%
+    miss_var_summary(add_cumsum = TRUE) %>%
     ggplot(aes(x = stats::reorder(variable, n_miss_cumsum),
                y = n_miss_cumsum,
                group = 1)) +

--- a/R/miss-x-cumsum.R
+++ b/R/miss-x-cumsum.R
@@ -7,6 +7,8 @@
 #'
 #' @return a tibble of the cumulative sum of missing data in each variable
 #'
+#' `r lifecycle::badge('deprecated')`
+#'
 #' @seealso  [pct_miss_case()] [prop_miss_case()] [pct_miss_var()] [prop_miss_var()] [pct_complete_case()] [prop_complete_case()] [pct_complete_var()] [prop_complete_var()] [miss_prop_summary()] [miss_case_summary()] [miss_case_table()] [miss_summary()] [miss_var_prop()] [miss_var_run()] [miss_var_span()] [miss_var_summary()] [miss_var_table()]
 #'
 #' @examples
@@ -23,6 +25,12 @@
 #'}
 #' @export
 miss_var_cumsum <- function(data){
+
+  lifecycle::deprecate_soft(
+    when = "1.1.0",
+    what = "miss_var_cumsum()",
+    details = "Please use `miss_var_summary(data, add_cumsum = TRUE)`"
+    )
 
   test_if_null(data)
 
@@ -63,6 +71,8 @@ miss_var_cumsum.grouped_df <- function(data){
 #' @return a tibble containing the number and percent of missing data in each
 #'   case
 #'
+#' `r lifecycle::badge('deprecated')`
+#'
 #' @examples
 #'
 #' miss_case_cumsum(airquality)
@@ -76,6 +86,12 @@ miss_var_cumsum.grouped_df <- function(data){
 #'}
 #' @export
 miss_case_cumsum <- function(data){
+
+  lifecycle::deprecate_soft(
+    when = "1.1.0",
+    what = "miss_case_cumsum()",
+    details = "Please use `miss_var_summary(data, add_cumsum = TRUE)`"
+  )
 
   test_if_null(data)
 

--- a/man/miss_case_cumsum.Rd
+++ b/man/miss_case_cumsum.Rd
@@ -12,6 +12,8 @@ miss_case_cumsum(data)
 \value{
 a tibble containing the number and percent of missing data in each
 case
+
+\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 }
 \description{
 Provide a data.frame containing each case (row), the number and percent of

--- a/man/miss_var_cumsum.Rd
+++ b/man/miss_var_cumsum.Rd
@@ -11,6 +11,8 @@ miss_var_cumsum(data)
 }
 \value{
 a tibble of the cumulative sum of missing data in each variable
+
+\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 }
 \description{
 Calculate the cumulative sum of number & percentage of

--- a/tests/testthat/_snaps/miss-var-case-cumsum.md
+++ b/tests/testthat/_snaps/miss-var-case-cumsum.md
@@ -1,0 +1,10 @@
+# miss_var_cumsum gives warning
+
+    `miss_var_cumsum()` was deprecated in naniar 1.1.0.
+    i Please use `miss_var_summary(data, add_cumsum = TRUE)`
+
+# miss_var_cumsum gives warning with grouping
+
+    `miss_var_cumsum()` was deprecated in naniar 1.1.0.
+    i Please use `miss_var_summary(data, add_cumsum = TRUE)`
+

--- a/tests/testthat/test-miss-var-case-cumsum.R
+++ b/tests/testthat/test-miss-var-case-cumsum.R
@@ -1,0 +1,12 @@
+library(dplyr)
+test_that("miss_var_cumsum gives warning", {
+  expect_snapshot_warning(
+    miss_var_cumsum(airquality)
+  )
+})
+
+test_that("miss_var_cumsum gives warning with grouping", {
+  expect_snapshot_warning(
+    miss_var_cumsum(group_by(airquality, Month))
+  )
+})


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

soft deprecate miss_case_cumsum and miss_var_cumsum

## Related Issue
<!--- if this closes an issue make sure include e.g., "fix #4"
or similar - or if just relates to an issue make sure to mention
it like "#4" -->

resolves #257

## Example
<!--- if introducing a new feature or changing behavior of existing
methods/functions, include an example if possible to do in brief form -->

``` r
library(naniar)
miss_var_cumsum(airquality)
#> Warning: `miss_var_cumsum()` was deprecated in naniar 1.1.0.
#> ℹ Please use `miss_var_summary(data, add_cumsum = TRUE)`
#> This warning is displayed once every 8 hours.
#> Call `lifecycle::last_lifecycle_warnings()` to see where this warning was
#> generated.
#> # A tibble: 6 × 3
#>   variable n_miss n_miss_cumsum
#>   <chr>     <int>         <int>
#> 1 Ozone        37            37
#> 2 Solar.R       7            44
#> 3 Wind          0            44
#> 4 Temp          0            44
#> 5 Month         0            44
#> 6 Day           0            44
miss_var_summary(airquality, add_cumsum = TRUE)
#> # A tibble: 6 × 4
#>   variable n_miss pct_miss n_miss_cumsum
#>   <chr>     <int>    <num>         <int>
#> 1 Ozone        37    24.2             37
#> 2 Solar.R       7     4.58            44
#> 3 Wind          0     0               44
#> 4 Temp          0     0               44
#> 5 Month         0     0               44
#> 6 Day           0     0               44

miss_case_cumsum(airquality)
#> Warning: `miss_case_cumsum()` was deprecated in naniar 1.1.0.
#> ℹ Please use `miss_var_summary(data, add_cumsum = TRUE)`
#> This warning is displayed once every 8 hours.
#> Call `lifecycle::last_lifecycle_warnings()` to see where this warning was
#> generated.
#> # A tibble: 153 × 3
#>     case n_miss n_miss_cumsum
#>    <int>  <int>         <int>
#>  1     1      0             0
#>  2     2      0             0
#>  3     3      0             0
#>  4     4      0             0
#>  5     5      2             2
#>  6     6      1             3
#>  7     7      0             3
#>  8     8      0             3
#>  9     9      0             3
#> 10    10      1             4
#> # ℹ 143 more rows
miss_case_summary(airquality, add_cumsum = TRUE)
#> # A tibble: 153 × 4
#>     case n_miss pct_miss n_miss_cumsum
#>    <int>  <int>    <dbl>         <int>
#>  1     5      2     33.3             2
#>  2    27      2     33.3             9
#>  3     6      1     16.7             3
#>  4    10      1     16.7             4
#>  5    11      1     16.7             5
#>  6    25      1     16.7             6
#>  7    26      1     16.7             7
#>  8    32      1     16.7            10
#>  9    33      1     16.7            11
#> 10    34      1     16.7            12
#> # ℹ 143 more rows
```

<sup>Created on 2023-05-02 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>

<details style="margin-bottom:10px;">
<summary>
Session info
</summary>

``` r
sessioninfo::session_info()
#> ─ Session info ───────────────────────────────────────────────────────────────
#>  setting  value
#>  version  R version 4.3.0 (2023-04-21)
#>  os       macOS Ventura 13.2
#>  system   aarch64, darwin20
#>  ui       X11
#>  language (EN)
#>  collate  en_US.UTF-8
#>  ctype    en_US.UTF-8
#>  tz       America/Los_Angeles
#>  date     2023-05-02
#>  pandoc   2.19.2 @ /Applications/RStudio.app/Contents/Resources/app/quarto/bin/tools/ (via rmarkdown)
#> 
#> ─ Packages ───────────────────────────────────────────────────────────────────
#>  package     * version    date (UTC) lib source
#>  cli           3.6.1      2023-03-23 [1] CRAN (R 4.3.0)
#>  colorspace    2.1-0      2023-01-23 [1] CRAN (R 4.3.0)
#>  crayon        1.5.2      2022-09-29 [1] CRAN (R 4.3.0)
#>  digest        0.6.31     2022-12-11 [1] CRAN (R 4.3.0)
#>  dplyr         1.1.2      2023-04-20 [1] CRAN (R 4.3.0)
#>  evaluate      0.20       2023-01-17 [1] CRAN (R 4.3.0)
#>  fansi         1.0.4      2023-01-22 [1] CRAN (R 4.3.0)
#>  fastmap       1.1.1      2023-02-24 [1] CRAN (R 4.3.0)
#>  fs            1.6.2      2023-04-25 [1] CRAN (R 4.3.0)
#>  generics      0.1.3      2022-07-05 [1] CRAN (R 4.3.0)
#>  ggplot2       3.4.2      2023-04-03 [1] CRAN (R 4.3.0)
#>  glue          1.6.2      2022-02-24 [1] CRAN (R 4.3.0)
#>  gtable        0.3.3      2023-03-21 [1] CRAN (R 4.3.0)
#>  htmltools     0.5.5      2023-03-23 [1] CRAN (R 4.3.0)
#>  knitr         1.42       2023-01-25 [1] CRAN (R 4.3.0)
#>  lifecycle     1.0.3      2022-10-07 [1] CRAN (R 4.3.0)
#>  magrittr      2.0.3      2022-03-30 [1] CRAN (R 4.3.0)
#>  munsell       0.5.0      2018-06-12 [1] CRAN (R 4.3.0)
#>  naniar      * 1.0.0.9000 2023-05-02 [1] local
#>  pillar        1.9.0      2023-03-22 [1] CRAN (R 4.3.0)
#>  pkgconfig     2.0.3      2019-09-22 [1] CRAN (R 4.3.0)
#>  purrr         1.0.1      2023-01-10 [1] CRAN (R 4.3.0)
#>  R.cache       0.16.0     2022-07-21 [1] CRAN (R 4.3.0)
#>  R.methodsS3   1.8.2      2022-06-13 [1] CRAN (R 4.3.0)
#>  R.oo          1.25.0     2022-06-12 [1] CRAN (R 4.3.0)
#>  R.utils       2.12.2     2022-11-11 [1] CRAN (R 4.3.0)
#>  R6            2.5.1      2021-08-19 [1] CRAN (R 4.3.0)
#>  reprex        2.0.2      2022-08-17 [1] CRAN (R 4.3.0)
#>  rlang         1.1.0      2023-03-14 [1] CRAN (R 4.3.0)
#>  rmarkdown     2.21       2023-03-26 [1] CRAN (R 4.3.0)
#>  rstudioapi    0.14       2022-08-22 [1] CRAN (R 4.3.0)
#>  scales        1.2.1      2022-08-20 [1] CRAN (R 4.3.0)
#>  sessioninfo   1.2.2      2021-12-06 [1] CRAN (R 4.3.0)
#>  styler        1.9.1      2023-03-04 [1] CRAN (R 4.3.0)
#>  tibble        3.2.1      2023-03-20 [1] CRAN (R 4.3.0)
#>  tidyr         1.3.0      2023-01-24 [1] CRAN (R 4.3.0)
#>  tidyselect    1.2.0      2022-10-10 [1] CRAN (R 4.3.0)
#>  utf8          1.2.3      2023-01-31 [1] CRAN (R 4.3.0)
#>  vctrs         0.6.2      2023-04-19 [1] CRAN (R 4.3.0)
#>  visdat        0.6.0      2023-02-02 [1] CRAN (R 4.3.0)
#>  withr         2.5.0      2022-03-03 [1] CRAN (R 4.3.0)
#>  xfun          0.39       2023-04-20 [1] CRAN (R 4.3.0)
#>  yaml          2.3.7      2023-01-23 [1] CRAN (R 4.3.0)
#> 
#>  [1] /Library/Frameworks/R.framework/Versions/4.3-arm64/Resources/library
#> 
#> ──────────────────────────────────────────────────────────────────────────────
```

</details>

## Tests
<!--- Did you remember to include tests? Unless you're just changing
grammar, please include new tests for your change -->

Yes

## NEWS + DESCRIPTION
<!--- If you added a new feature or changed behaviour, describe the new/changed behaviour in the NEWS.md file. If it is a new feature, please bump the version in the DESCRIPTION and NEWS.md files  -->

Yes
