### PR TITLE
Add percentage and default sorting to miss_scan_count (Fix #341)

### DIFF
--- a/R/miss-scan-count.R
+++ b/R/miss-scan-count.R
@@ -58,7 +58,8 @@ miss_scan_count <- function(data,search){
                                       x = .))) %>%
       tidyr::pivot_longer(cols = dplyr::everything(),
                           names_to = "Variable",
-                          values_to = "n")
+                          values_to = "n") %>%
+      tidyr::arrange(desc(n))
   }
 
   return(res)

--- a/tests/testthat/test-miss-scan-count.R
+++ b/tests/testthat/test-miss-scan-count.R
@@ -25,37 +25,30 @@ test_that("miss_scan_count returns an error when no data is provided", {
 test_that("miss_scan_count returns a data.frame of the right size", {
   expect_equal(
     dim(miss_scan_count(dat_ms, -99)),
-    c(3, 2)
+    c(3, 3)
   )
 })
 
+test_that("miss_scan_count returns results sorted in descending order by 'n'", {
+  result <- miss_scan_count(dat_ms, c(-99, -98))
+  n_values <- result$n
+  expect_true(all(n_values == sort(n_values, decreasing = TRUE)))
+})
+
 correct_answer_1 <- tibble::tribble(
-  ~Variable, ~n,
-  "x", 1L,
-  "y", 0L,
-  "z", 1L
+  ~Variable, ~n, ~pct,
+  "x", 1L, 20,
+  "z", 1L, 20,
+  "y", 0L, 0
 )
 
 correct_answer_2 <- tibble::tribble(
-  ~Variable, ~n,
-  "x", 2L,
-  "y", 0L,
-  "z", 2L
+  ~Variable, ~n, ~pct,
+  "x", 2L, 40,
+  "z", 2L, 40,
+  "y", 0L, 0
 )
 
-correct_answer_3 <- tibble::tribble(
-  ~Variable, ~n,
-  "x", 2L,
-  "y", 1L,
-  "z", 2L
-)
-
-correct_answer_4 <- tibble::tribble(
-  ~Variable, ~n,
-  "x", 2L,
-  "y", 1L,
-  "z", 2L
-)
 
 test_that("miss_scan_count returns the right answer", {
   expect_equal(miss_scan_count(dat_ms,-99),


### PR DESCRIPTION
## Description
This PR updates `miss_scan_count()`:

- A new column `pct` that shows the percentage of matches per column.

- Default sorting of results in descending order by `count (n)`.

- Unified logic for handling both single and multiple search terms using `paste0()` and `grepl` functions.

## Related Issue
Fix #341 


## Example

```
dat_ms <- tibble::tribble(~x,  ~y,    ~z,  ~specials,
+                           1,   "A",   -100, "?",
+                           3,   "N/A", -99,  "!",
+                           NA,  NA,    -98,  ".",
+                           -99, "E",   -101, "*",
+                           -98, "F",   -1,  "-")
> miss_scan_count(dat_ms,-99)
# A tibble: 4 × 3
  Variable     n   pct
  <chr>    <int> <dbl>
1 x            1    20
2 z            1    20
3 y            0     0
4 specials     0     0
> miss_scan_count(dat_ms,c(-99,-98))
# A tibble: 4 × 3
  Variable     n   pct
  <chr>    <int> <dbl>
1 x            2    40
2 z            2    40
3 y            0     0
4 specials     0     0
> miss_scan_count(dat_ms,c("-99","-98","N/A"))
# A tibble: 4 × 3
  Variable     n   pct
  <chr>    <int> <dbl>
1 x            2    40
2 z            2    40
3 y            1    20
4 specials     0     0
> miss_scan_count(dat_ms, "\\?")
# A tibble: 4 × 3
  Variable     n   pct
  <chr>    <int> <dbl>
1 specials     1    20
2 x            0     0
3 y            0     0
4 z            0     0
> miss_scan_count(dat_ms, "\\!")
# A tibble: 4 × 3
  Variable     n   pct
  <chr>    <int> <dbl>
1 specials     1    20
2 x            0     0
3 y            0     0
4 z            0     0
> miss_scan_count(dat_ms, "\\.")
# A tibble: 4 × 3
  Variable     n   pct
  <chr>    <int> <dbl>
1 specials     1    20
2 x            0     0
3 y            0     0
4 z            0     0
> miss_scan_count(dat_ms, "\\*")
# A tibble: 4 × 3
  Variable     n   pct
  <chr>    <int> <dbl>
1 specials     1    20
2 x            0     0
3 y            0     0
4 z            0     0
> miss_scan_count(dat_ms, "-")
# A tibble: 4 × 3
  Variable     n   pct
  <chr>    <int> <dbl>
1 z            5   100
2 x            2    40
3 specials     1    20
4 y            0     0
```


## Tests
`test-miss-scan-count` was updated accordingly.
